### PR TITLE
Don't error on upgrade no-op

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -66,7 +66,6 @@ if git pull --rebase --stat origin master; then
   # Check if it was really updated or not
   if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
     message="Oh My Zsh is already at the latest version."
-    ret=80 # non-zero exit code to indicate no changes pulled
   else
     message="Hooray! Oh My Zsh has been updated!"
 


### PR DESCRIPTION
No error code is required for a non failure scenario.
